### PR TITLE
Dev - NR6 changes

### DIFF
--- a/nr6_hal/HAC_fnc.sqf
+++ b/nr6_hal/HAC_fnc.sqf
@@ -1977,7 +1977,7 @@ RYD_Wait =
 
 			if (_enemyF > 0) then
 				{
-				if not (_GDV in _air) then {_enemy = [_AV,_enG,_enemyF] call RYD_CloseEnemy}
+				if not ((_GDV in _air) and not (_own)) then {_enemy = [_AV,_enG,_enemyF] call RYD_CloseEnemy}
 				} else {
 				if not (_GDV in _air) then {_enPres = [_AV,_enG,RydxHQ_DisembarkRange] call RYD_CloseEnemy}
 				};

--- a/nr6_hal/HAC_fnc2.sqf
+++ b/nr6_hal/HAC_fnc2.sqf
@@ -1150,7 +1150,7 @@ RYD_StatusQuo =
 				_objStr = (_prefix + (_objStr splitString " " joinstring ""));
 				if (_x in _taken) then {
 					if ((getMarkerColor _objStr) == "") then {
-						_Rmrk = createMarker [_objStr,[_x, 1, 150, 3, 0, 20, 0] call BIS_fnc_findSafePos];
+						_Rmrk = createMarker [_objStr,[_x, 1, 75, 2, 0, 20, 0] call BIS_fnc_findSafePos];
 						if not ((_x getvariable ["ObjName",""]) isEqualTo "") then {_Rmrk setMarkerText (_x getvariable ["ObjName",""])};
 					};
 

--- a/nr6_hal/HAC_fnc2.sqf
+++ b/nr6_hal/HAC_fnc2.sqf
@@ -1133,7 +1133,40 @@ RYD_StatusQuo =
 		_HQ setVariable ["RydHQ_Taken",_taken];
 		_HQ setVariable ["RydHQ_TakenNaval",_Navaltaken];
 
+		if (_HQ getVariable ["RydHQ_ObjectiveRespawn",false]) then {
+			
+			_prefix = "";
+
+			switch (side _HQ) do
+			{
+				case west: {_prefix = "respawn_west_"};
+				case east: {_prefix = "respawn_east_"};
+				case resistance: {_prefix = "respawn_guerrila_"};
+				case civilian: {_prefix = "respawn_civilian_"};
+			};
+
+			{
+				_objStr = (str _x);
+				_objStr = (_prefix + (_objStr splitString " " joinstring ""));
+				if (_x in _taken) then {
+					if ((getMarkerColor _objStr) == "") then {
+						_Rmrk = createMarker [_objStr,[_x, 1, 150, 3, 0, 20, 0] call BIS_fnc_findSafePos];
+						if not ((_x getvariable ["ObjName",""]) isEqualTo "") then {_Rmrk setMarkerText (_x getvariable ["ObjName",""])};
+					};
+
+				} else {
+					if not ((getMarkerColor _objStr) == "") then {
+						deleteMarker _objStr;
+					};
+				}
+
+			} foreach (_HQ getVariable ["RydHQ_Objectives",[]]);
+
+		};
+
 	};
+
+	
 
 	_objs = (((_HQ getVariable ["RydHQ_Objectives",[]]) + (_HQ getVariable ["RydHQ_NavalObjectives",[]])) - ((_HQ getVariable ["RydHQ_Taken",[]]) + (_HQ getVariable ["RydHQ_TakenNaval",[]])));
 	

--- a/nr6_hal/HAL/GoAttAir.sqf
+++ b/nr6_hal/HAL/GoAttAir.sqf
@@ -14,8 +14,8 @@ _unitvar = str (_unitG);
 
 _UL = leader _unitG;
 
-_PosLand = getPosASL (leader _unitG);
-if (isNil ("_PosLand")) then {_unitG setVariable [("START" + _unitvar),(position (vehicle (leader _unitG)))]};
+_PosLand = _unitG getvariable ("START" + _unitvar); 
+if (isNil ("_PosLand")) then {_unitG setVariable [("START" + _unitvar),(position (vehicle _UL))];_PosLand = _unitG getvariable ("START" + _unitvar);};
 
 [_unitG] call RYD_WPdel;
 

--- a/nr6_hal/HAL/GoAttAirCAP.sqf
+++ b/nr6_hal/HAL/GoAttAirCAP.sqf
@@ -13,7 +13,7 @@ _unitvar = str (_unitG);
 
 _UL = leader _unitG;
 _PosLand = _unitG getvariable ("START" + _unitvar); 
-if (isNil ("_PosLand")) then {_unitG setVariable [("START" + _unitvar),(position (vehicle _UL))]};
+if (isNil ("_PosLand")) then {_unitG setVariable [("START" + _unitvar),(position (vehicle _UL))];_PosLand = _unitG getvariable ("START" + _unitvar);};
 
 [_unitG] call RYD_WPdel;
 

--- a/nr6_hal/HAL/GoRecon.sqf
+++ b/nr6_hal/HAL/GoRecon.sqf
@@ -33,7 +33,10 @@ _reconAv = _reconAv - [_unitG];
 _HQ setVariable ["RydHQ_ReconAv",_reconAv];
 
 _UL = leader _unitG;
-_PosLand = getPosATL _UL;
+
+_PosLand = _unitG getvariable ("START" + _unitvar); 
+if (isNil ("_PosLand")) then {_unitG setVariable [("START" + _unitvar),(position (vehicle _UL))];_PosLand = _unitG getvariable ("START" + _unitvar);};
+
 _nothing = true;
 _End = [((getPosATL (leader _HQ)) select 0) + (random 400) - 200,((getPosATL (leader _HQ)) select 1) + (random 400) - 200];
 _rd = 200;
@@ -570,7 +573,9 @@ if not (_IsAPlayer) then {
 		{
 	//	_unitG setVariable ["RydHQ_WaitingObjective",[_HQ,_trg]];
 		if not (_isAPlayer) then {_unitG setVariable ["InfGetinCheck" + (str _unitG),true]};
-		_cause = [_unitG,6,true,400,30,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]]),_HQ],false] call RYD_Wait;
+		_enRg = 400;
+		if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {_enRg = 1000};
+		_cause = [_unitG,6,true,_enRG,30,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]]),_HQ],false] call RYD_Wait;
 		_timer = _cause select 0;
 		_alive = _cause select 1;
 		_enemy = _cause select 2;
@@ -673,7 +678,7 @@ if not (_Ctask isEqualTo taskNull) then {[_Ctask,"SUCCEEDED",true] call BIS_fnc_
 
 _unitvar = str _GDV;
 _timer = 0;
-if (not (isNull _GDV) and (_GDV in (_HQ getVariable ["RydHQ_AirG",[]])) and not (isPlayer (leader _GDV)) and not (_IsAPlayer)) then
+if (not (isNull _GDV) and not (_GDV == _unitG) and (_GDV in (_HQ getVariable ["RydHQ_AirG",[]])) and not (isPlayer (leader _GDV)) and not (_IsAPlayer)) then
 	{
 	_wp = [_GDV,[((getPosATL _AV) select 0) + (random 200) - 100,((getPosATL _AV) select 1) + (random 200) - 100,1000],"MOVE","STEALTH","YELLOW","NORMAL"] call RYD_WPadd;
 	
@@ -723,7 +728,9 @@ _wp = [_unitG,[_posX,_posY],"SAD",_beh,"GREEN","NORMAL",["true","deletewaypoint 
 
 //_unitG setVariable ["RydHQ_WaitingObjective",[_HQ,_trg]];
 if not (_isAPlayer) then {_unitG setVariable ["InfGetinCheck" + (str _unitG),true]};
-_cause = [_unitG,6,true,250,30,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]])],false] call RYD_Wait;
+_enRg = 250;
+if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {_enRg = 1000};
+_cause = [_unitG,6,true,_enRg,30,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]]),_HQ],false] call RYD_Wait;
 _alive = _cause select 1;
 
 if not (_alive) exitwith {_unitG setVariable [("Busy" + (str _unitG)),false];if ((_HQ getVariable ["RydHQ_Debug",false]) or (isPlayer (leader _unitG))) then {deleteMarker ("markRecon" + str (_unitG))}};
@@ -741,7 +748,9 @@ if (_unitG in (_HQ getVariable ["RydHQ_FOG",[]])) then
 	_wp = [_unitG,[_posX,_posY],"MOVE",_beh,"GREEN","NORMAL",["true","deletewaypoint [(group this), 0];"],true,0.001,[0,0,0],_frm] call RYD_WPadd;
 
 	if not (_isAPlayer) then {_unitG setVariable ["InfGetinCheck" + (str _unitG),true]};
-	_cause = [_unitG,6,true,150,120,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]])],false] call RYD_Wait;
+	_enRg = 150;
+	if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {_enRg = 750};
+	_cause = [_unitG,6,true,_enRg,120,[(_HQ getVariable ["RydHQ_AirG",[]]),(_HQ getVariable ["RydHQ_KnEnemiesG",[]]),_HQ],false] call RYD_Wait;
 	_timer = _cause select 0;
 	_alive = _cause select 1;
 	_enemy = _cause select 2
@@ -757,11 +766,38 @@ if ((_HQ getVariable ["RydHQ_Debug",false]) or (isPlayer (leader _unitG))) then 
 //if not (_specialized) exitWith
 if (true) exitwith	
 	{
-	
+
 	if not (isNull _unitG) then
 		{
 		if (({alive _x} count (units _unitG)) > 0) then
 			{
+			if not (isNull (_UL findNearestEnemy _UL)) then
+				{
+				if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {
+					_End = _PosLand;_rd = 0
+				} else {
+					if ((count (_HQ getVariable ["RydHQ_Taken",[]])) > 0) then {_End = (([(_HQ getVariable ["RydHQ_Taken",[]]), [], {(position (leader _unitG)) distance _x }, "ASCEND",{true}] call BIS_fnc_sortBy) select 0); _End = getPosATL _End;} else {_End = [((getPosATL (leader _HQ)) select 0) + (random 400) - 200,((getPosATL (leader _HQ)) select 1) + (random 400) - 200];};
+					_isWater = surfaceIsWater _End; 
+					if (_isWater) then {_End = [((getPosATL (leader _HQ)) select 0) + (random 40) - 20,((getPosATL (leader _HQ)) select 1) + (random 40) - 20]}
+				};
+
+				if not (_task isEqualTo taskNull) then
+					{
+						
+					[_task,(leader _unitG),["Break away from enemy contact. Stand-by for new orders.", "Break Enemy Contact", ""],_End,"ASSIGNED",0,true,true] call BIS_fnc_SetTask;
+						
+					};
+
+				_beh = "AWARE";
+				if (_unitG in (_HQ getVariable ["RydHQ_RAirG",[]])) then {_beh = "STEALTH"};
+				_sts = ["true", "deletewaypoint [(group this), 0];"];
+				if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {_sts = ["true", "{(vehicle _x) land 'LAND'} foreach (units (group this));deletewaypoint [(group this), 0];"]};
+
+				[_unitG] call RYD_WPdel;
+
+				_wp = [_unitG,_End,"MOVE",_beh,"GREEN","FULL",_sts] call RYD_WPadd;
+				};
+
 			if not (_unitG getVariable ["RydHQ_MIA",false]) then
 				{
 				if (_unitG in (_HQ getVariable ["RydHQ_NCrewInfG",[]])) then 
@@ -781,7 +817,7 @@ if (true) exitwith
 				};
 				
 			if ((_HQ getVariable ["RydHQ_Debug",false]) or (isPlayer (leader _unitG))) then {deleteMarker ("markRecon" + str (_unitG))}
-			}
+			};
 		};
 		_unitG setVariable [("Busy" + (str _unitG)),false];
 	};
@@ -793,6 +829,7 @@ while {(_nothing)} do
 	{
 	sleep 5;
 	_unitG = group (leader (_this select 0));
+	if (_unitG getVariable ["Break",false]) then {_nothing = false;_unitG setVariable ["Break",false]};
 	if (((not (isNull (_UL findNearestEnemy _UL)) or (_timer2 > 4)) and not (isNull _unitG) and not (_unitG in (_HQ getVariable ["RydHQ_FOG",[]]))) or ((_timer2 > 40) and not (isNull _unitG))) then 
 		{
 
@@ -816,7 +853,13 @@ while {(_nothing)} do
 			};
 			
 		_rd = 0;
-		if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {_End = _PosLand;_rd = 0} else {_End = [((getPosATL (leader _HQ)) select 0) + (random 400) - 200,((getPosATL (leader _HQ)) select 1) + (random 400) - 200];_isWater = surfaceIsWater _End;if (_isWater) then {_End = [((getPosATL (leader _HQ)) select 0) + (random 40) - 20,((getPosATL (leader _HQ)) select 1) + (random 40) - 20]}};
+		if (_unitG in (_HQ getVariable ["RydHQ_AirG",[]])) then {
+			_End = _PosLand;_rd = 0
+		} else {
+			if ((count (_HQ getVariable ["RydHQ_Taken",[]])) > 0) then {_End = (([(_HQ getVariable ["RydHQ_Taken",[]]), [], {(position (leader _unitG)) distance _x }, "ASCEND",{true}] call BIS_fnc_sortBy) select 0)} else {_End = [((getPosATL (leader _HQ)) select 0) + (random 400) - 200,((getPosATL (leader _HQ)) select 1) + (random 400) - 200];};
+			_isWater = surfaceIsWater _End; 
+			if (_isWater) then {_End = [((getPosATL (leader _HQ)) select 0) + (random 40) - 20,((getPosATL (leader _HQ)) select 1) + (random 40) - 20]}
+		};
 
 		if not (_task isEqualTo taskNull) then
 			{
@@ -865,8 +908,10 @@ while {(_nothing)} do
 				};
 			};
 		if ((_HQ getVariable ["RydHQ_Debug",false]) or (isPlayer (leader _unitG))) then {deleteMarker ("markRecon" + str (_unitG))};
+		if (_unitG getVariable ["Break",false]) then {_nothing = false;_unitG setVariable ["Break",false]};
 		_unitG setVariable [("Busy" + (str _unitG)), false];
 		};
+	if (_unitG getVariable ["Break",false]) then {_nothing = false;_unitG setVariable ["Break",false]};
 	_timer2 = _timer2 + 1;
 	};
 

--- a/nr6_hal/HAL/HQReset.sqf
+++ b/nr6_hal/HAL/HQReset.sqf
@@ -509,7 +509,7 @@ if ((_HQ getVariable ["RydHQ_Combining",false])) then
 					if not (_Aex getVariable [("isCaptive" + _unitvarA),false]) then
 						{
 						_nominalA = _Aex getVariable ("Nominal" + (str _Aex));
-						if (isNil ("_nominal")) then {
+						if (isNil ("_nominalA")) then {
 							_Aex setVariable [("Nominal" + _unitvarA),(count (units _Aex)),true];
 							_nominalA = _Aex getVariable ("Nominal" + (str _Aex))
 							};

--- a/nr6_hal/HAL_Version.sqf
+++ b/nr6_hal/HAL_Version.sqf
@@ -1,1 +1,1 @@
-HAL_Ver = "HAL 1.26.2 EX 1.2 - [NR6 Pack]";
+HAL_Ver = "HAL 1.26.2 RC2 EX 1.0 - [NR6 Pack]";

--- a/nr6_hal/HAL_Version.sqf
+++ b/nr6_hal/HAL_Version.sqf
@@ -1,1 +1,1 @@
-HAL_Ver = "HAL 1.26.2 RC2 EX 1.0 - [NR6 Pack]";
+HAL_Ver = "HAL 1.26.2 RC2 EX 1.1 - [NR6 Pack]";

--- a/nr6_hal/Modules/LeaderObjectivesSettings.sqf
+++ b/nr6_hal/Modules/LeaderObjectivesSettings.sqf
@@ -44,4 +44,8 @@ _Commanders = [];
 	_logic call compile (_prefix + "MaxSimpleObjs" + " = " + str (_logic getvariable "RydHQ_MaxSimpleObjs"));
 	_logic call compile (_prefix + "CRDefRes" + " = " + str (_logic getvariable "RydHQ_CRDefRes"));
 
+//New Variables
+
+	(group _Leader) setVariable ["RydHQ_ObjectiveRespawn",(_logic getvariable ["RydHQ_ObjectiveRespawn",true])];
+
 } foreach _Commanders;

--- a/nr6_hal/Modules/LeaderObjectivesSettings.sqf
+++ b/nr6_hal/Modules/LeaderObjectivesSettings.sqf
@@ -19,8 +19,6 @@ _Commanders = [];
 	if (_Leader == "LeaderHQG") then {_prefix = "RydHQG_"};
 	if (_Leader == "LeaderHQH") then {_prefix = "RydHQH_"};
 
-	_Leader = call compile _Leader;
-
 
 	if (_logic getvariable "RydHQ_Order") then {_logic call compile (_prefix + "Order" + " = " + str "DEFEND")};
 	
@@ -43,6 +41,10 @@ _Commanders = [];
 	_logic call compile (_prefix + "BBAOObj" + " = " + str (_logic getvariable "RydHQ_BBAOObj"));
 	_logic call compile (_prefix + "MaxSimpleObjs" + " = " + str (_logic getvariable "RydHQ_MaxSimpleObjs"));
 	_logic call compile (_prefix + "CRDefRes" + " = " + str (_logic getvariable "RydHQ_CRDefRes"));
+
+	waitUntil {sleep 0.5; (not (isNil _Leader))};
+
+	_Leader = call compile _Leader;
 
 //New Variables
 

--- a/nr6_hal/config.cpp
+++ b/nr6_hal/config.cpp
@@ -1196,6 +1196,13 @@ class CfgVehicles
 				typeName="NUMBER";
 				defaultValue = "5";
 			};
+			class RydHQ_ObjectiveRespawn
+			{
+				displayName="Create Objective Player Respawn Points";
+				description="Creates a player respawn position for every taken objective.";
+				typeName="BOOL";
+				defaultValue = "False";
+			};
 		};
 		class ModuleDescription: ModuleDescription
 		{


### PR DESCRIPTION
- Redesigned breaking away from enemy contact for recon missions;
- Made threshold for RTB upon contact more sensitive for air units.
- Fixed error linked to withdraw orders; 
- Added better compliance with RTB behavior when enemy contact is met by Air Recon units. 
- Lowered range of respawn around objective to 75m; 
- Added commander setting for objectives to act as respawn points when taken by commander of the player's side.